### PR TITLE
Make E generic Throwable in `attempt` function

### DIFF
--- a/src/Result/functions.php
+++ b/src/Result/functions.php
@@ -31,7 +31,7 @@ function Err(mixed $err): Err
 /**
  * @template T
  * @template E of Throwable
- * @param callable(): T $f
+ * @param callable(): T @throws E $f
  * @return Result<T, E>
  */
 function attempt(callable $f): Result

--- a/src/Result/functions.php
+++ b/src/Result/functions.php
@@ -31,7 +31,7 @@ function Err(mixed $err): Err
 /**
  * @template T
  * @template E of Throwable
- * @param callable(): T @throws E $f
+ * @param callable(): T $f
  * @return Result<T, E>
  */
 function attempt(callable $f): Result
@@ -39,6 +39,7 @@ function attempt(callable $f): Result
     try {
         return Ok($f());
     } catch (Throwable $e) {
+        /** @var E $e */
         return Err($e);
     }
 }

--- a/src/Result/functions.php
+++ b/src/Result/functions.php
@@ -32,14 +32,13 @@ function Err(mixed $err): Err
  * @template T
  * @template E of Throwable
  * @param callable(): T $f
- * @return Result<T, E>
+ * @return Result<T, E|Throwable>
  */
 function attempt(callable $f): Result
 {
     try {
         return Ok($f());
     } catch (Throwable $e) {
-        /** @var E $e */
         return Err($e);
     }
 }

--- a/src/Result/functions.php
+++ b/src/Result/functions.php
@@ -30,8 +30,9 @@ function Err(mixed $err): Err
 
 /**
  * @template T
+ * @template E of Throwable
  * @param callable(): T $f
- * @return Result<T, Throwable>
+ * @return Result<T, E>
  */
 function attempt(callable $f): Result
 {


### PR DESCRIPTION
This PR makes the E passed to the Result PHP return doc for the `attempt` helper function a generic of type Throwable, allowing for improved PHPStan reporting with functions that already return typed `Result`s in PHP doc:

```php
  * @return Result<MyObj, CustomThrowable>
```

This will fix handling `match` or `orElse` calls where strongly typing the known exception type in the passed closure is preferred over `fn(Throwable $t) => handler(...)`