### PR TITLE
feat: pass Throwable on Result::expect

### DIFF
--- a/src/Result/Err.php
+++ b/src/Result/Err.php
@@ -46,6 +46,10 @@ final readonly class Err extends Result
             throw $message;
         }
 
+        if ($this->err instanceof Throwable) {
+            throw new RuntimeException($message, previous: $this->err);
+        }
+
         throw new RuntimeException($message);
     }
 

--- a/src/Result/Ok.php
+++ b/src/Result/Ok.php
@@ -47,7 +47,11 @@ final readonly class Ok extends Result
 
     public function expectErr(Throwable|string $message): mixed
     {
-        throw $message instanceof Throwable ? $message : new RuntimeException($message);
+        if ($message instanceof Throwable) {
+            throw $message;
+        }
+
+        throw new RuntimeException($message);
     }
 
     public function inspect(callable $f): Result


### PR DESCRIPTION
PHPUnit and Sentry will now report the underlying exception when calling `expect`.