### PR TITLE
Add Writer monad implementation with comprehensive tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,8 @@
     },
     "files": [
       "src/Result/functions.php",
-      "src/Option/functions.php"
+      "src/Option/functions.php",
+      "src/Writer/functions.php"
     ]
   },
   "autoload-dev": {

--- a/src/Option/None.php
+++ b/src/Option/None.php
@@ -6,7 +6,6 @@ namespace Superscript\Monads\Option;
 
 use RuntimeException;
 use Superscript\Monads\Result\Result;
-
 use Throwable;
 
 use function Superscript\Monads\Result\Err;

--- a/src/Option/Some.php
+++ b/src/Option/Some.php
@@ -132,6 +132,6 @@ final readonly class Some extends Option
             throw new InvalidArgumentException('Cannot transpose a Some value that is not a Result');
         }
 
-        return $this->value->andThen(fn ($value) => Ok(new self($value)));
+        return $this->value->andThen(fn($value) => Ok(new self($value)));
     }
 }

--- a/src/Result/Err.php
+++ b/src/Result/Err.php
@@ -9,6 +9,7 @@ use Superscript\Monads\Option\None;
 use Superscript\Monads\Option\Option;
 use Superscript\Monads\Option\Some;
 use Throwable;
+
 use function Superscript\Monads\Option\Some;
 
 /**

--- a/src/Result/Ok.php
+++ b/src/Result/Ok.php
@@ -37,7 +37,7 @@ final readonly class Ok extends Result
 
     public function err(): Option
     {
-        return new None;
+        return new None();
     }
 
     public function expect(string|Throwable $message): mixed
@@ -150,6 +150,6 @@ final readonly class Ok extends Result
             throw new InvalidArgumentException('Cannot transpose an Ok value that is not an Option');
         }
 
-        return $this->value->map(fn ($value) => new self($value));
+        return $this->value->map(fn($value) => new self($value));
     }
 }

--- a/src/Writer/Writer.php
+++ b/src/Writer/Writer.php
@@ -1,0 +1,175 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Superscript\Monads\Writer;
+
+use Closure;
+
+/**
+ * A Writer monad that carries a value alongside an accumulated log.
+ *
+ * The log is combined using a provided combiner function, allowing
+ * flexible log types (arrays, strings, or any monoid-like type).
+ *
+ * @template W The log type
+ * @template-covariant T The value type
+ */
+final readonly class Writer
+{
+    /**
+     * @param T $value
+     * @param W $log
+     * @param Closure(W, W): W $combiner
+     */
+    private function __construct(
+        private mixed $value,
+        private mixed $log,
+        private Closure $combiner,
+    ) {}
+
+    /**
+     * Create a Writer with a value, initial log, and combiner function.
+     *
+     * @template WNew
+     * @template TNew
+     *
+     * @param TNew $value
+     * @param WNew $log
+     * @param Closure(WNew, WNew): WNew $combiner
+     * @return self<WNew, TNew>
+     */
+    public static function of(mixed $value, mixed $log, Closure $combiner): self
+    {
+        return new self($value, $log, $combiner);
+    }
+
+    /**
+     * Returns the contained value.
+     *
+     * @return T
+     */
+    public function value(): mixed
+    {
+        return $this->value;
+    }
+
+    /**
+     * Returns the accumulated log.
+     *
+     * @return W
+     */
+    public function log(): mixed
+    {
+        return $this->log;
+    }
+
+    /**
+     * Returns both the value and the log as a tuple.
+     *
+     * @return array{T, W}
+     */
+    public function run(): array
+    {
+        return [$this->value, $this->log];
+    }
+
+    /**
+     * Transforms the value by applying a function, leaving the log unchanged.
+     *
+     * @template U
+     *
+     * @param callable(T): U $f
+     * @return self<W, U>
+     */
+    public function map(callable $f): self
+    {
+        return new self($f($this->value), $this->log, $this->combiner);
+    }
+
+    /**
+     * Chains a computation that returns a Writer, combining the logs.
+     *
+     * Some languages call this operation flatmap or bind.
+     *
+     * @template U
+     *
+     * @param callable(T): self<W, U> $f
+     * @return self<W, U>
+     */
+    public function andThen(callable $f): self
+    {
+        /** @var self<W, U> $result */
+        $result = $f($this->value);
+
+        return new self(
+            $result->value,
+            ($this->combiner)($this->log, $result->log),
+            $this->combiner,
+        );
+    }
+
+    /**
+     * Appends an entry to the log without changing the value.
+     *
+     * @param W $entry
+     * @return self<W, T>
+     */
+    public function tell(mixed $entry): self
+    {
+        return new self(
+            $this->value,
+            ($this->combiner)($this->log, $entry),
+            $this->combiner,
+        );
+    }
+
+    /**
+     * Transforms the log by applying a function, leaving the value unchanged.
+     *
+     * @param callable(W): W $f
+     * @return self<W, T>
+     */
+    public function mapLog(callable $f): self
+    {
+        return new self($this->value, $f($this->log), $this->combiner);
+    }
+
+    /**
+     * Calls the provided closure with the contained value (for side effects).
+     *
+     * @param callable(T): void $f
+     * @return self<W, T>
+     */
+    public function inspect(callable $f): self
+    {
+        $f($this->value);
+
+        return $this;
+    }
+
+    /**
+     * Resets the log to the given value, leaving the value unchanged.
+     *
+     * @param W $log
+     * @return self<W, T>
+     */
+    public function reset(mixed $log): self
+    {
+        return new self($this->value, $log, $this->combiner);
+    }
+
+    /**
+     * Accesses both the value and the log, returning a new Writer with the
+     * callback's return value as the new value, and the log unchanged.
+     *
+     * @template U
+     *
+     * @param callable(T, W): U $f
+     * @return self<W, U>
+     */
+    public function listen(callable $f): self
+    {
+        return new self($f($this->value, $this->log), $this->log, $this->combiner);
+    }
+}

--- a/src/Writer/functions.php
+++ b/src/Writer/functions.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Superscript\Monads\Writer;
+
+/**
+ * Create a Writer with an array-based log.
+ *
+ * The log entries are combined using array spread (array_merge-like behavior).
+ *
+ * @template T
+ *
+ * @param T $value
+ * @param list<mixed> $log
+ * @return Writer<list<mixed>, T>
+ */
+function Writer(mixed $value, array $log = []): Writer
+{
+    $combiner = /** @param list<mixed> $a @param list<mixed> $b @return list<mixed> */ fn(array $a, array $b): array => array_values([...$a, ...$b]);
+
+    return Writer::of($value, $log, $combiner);
+}

--- a/tests/Lazy/LazyTypeTest.php
+++ b/tests/Lazy/LazyTypeTest.php
@@ -22,7 +22,7 @@ class LazyTypeTest extends TypeInferenceTestCase
     public function testFileAsserts(
         string $assertType,
         string $file,
-        mixed ...$args
+        mixed ...$args,
     ): void {
         $this->assertFileAsserts($assertType, $file, ...$args);
     }

--- a/tests/Option/OptionTest.php
+++ b/tests/Option/OptionTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 use Superscript\Monads\Option\CannotUnwrapNone;
 use Superscript\Monads\Option\Option;
-
 use Superscript\Monads\Result\Result;
 
 use function Superscript\Monads\Option\None;
@@ -187,7 +186,7 @@ test('transpose', function (Option $option, mixed $expected) {
 ]);
 
 test('transpose with non-result', function (Option $option) {
-    expect(fn () => $option->transpose())->toThrow(new InvalidArgumentException('Cannot transpose a Some value that is not a Result'));
+    expect(fn() => $option->transpose())->toThrow(new InvalidArgumentException('Cannot transpose a Some value that is not a Result'));
 })->with([
     [Some(2), Some(2)],
 ]);

--- a/tests/Option/OptionTypeTest.php
+++ b/tests/Option/OptionTypeTest.php
@@ -22,7 +22,7 @@ class OptionTypeTest extends TypeInferenceTestCase
     public function testFileAsserts(
         string $assertType,
         string $file,
-        mixed ...$args
+        mixed ...$args,
     ): void {
         $this->assertFileAsserts($assertType, $file, ...$args);
     }

--- a/tests/Option/types.php
+++ b/tests/Option/types.php
@@ -66,4 +66,4 @@ assertType(Option::class . '<int>', $x->xor($y));
 assertType(Option::class . '<list<int>>', Option::collect($items));
 
 /** @var Option<Result<int, Throwable>> $x */
-assertType(Result::class . '<'.Option::class.'<int>, '.Throwable::class.'>', $x->transpose());
+assertType(Result::class . '<' . Option::class . '<int>, ' . Throwable::class . '>', $x->transpose());

--- a/tests/Result/ResultTest.php
+++ b/tests/Result/ResultTest.php
@@ -2,7 +2,6 @@
 
 declare(strict_types=1);
 
-use Superscript\Monads\Option\Option;
 use Superscript\Monads\Result\CannotUnwrapErr;
 use Superscript\Monads\Result\Err;
 use Superscript\Monads\Result\Ok;
@@ -192,21 +191,21 @@ test('unwrap or', function (Result $result, mixed $other, mixed $expected) {
     expect($result->unwrapOr($other))->toEqual($expected);
 })->with([
     [Ok(9), 2, 9],
-    [Err('err'), 2, 2]
+    [Err('err'), 2, 2],
 ]);
 
 test('unwrap or else', function (Result $result, callable $op, mixed $expected) {
     expect($result->unwrapOrElse($op))->toEqual($expected);
 })->with([
     [Ok(2), strlen(...), 2],
-    [Err('foo'), strlen(...), 3]
+    [Err('foo'), strlen(...), 3],
 ]);
 
 test('unwrap either', function (Result $result, mixed $expected) {
     expect($result->unwrapEither())->toEqual($expected);
 })->with([
     [Ok(42), 42],
-    [Err('foo'), 'foo']
+    [Err('foo'), 'foo'],
 ]);
 
 test('into ok', function (Ok $ok, mixed $expected) {
@@ -225,7 +224,7 @@ test('collect', function (array $items, Result $expected) {
     expect(Result::collect($items))->toEqual($expected);
 })->with([
     [[Ok(1), Ok(2)], Ok([1, 2])],
-    [[Err('error')], Err('error')]
+    [[Err('error')], Err('error')],
 ]);
 
 test('attempt', function () {

--- a/tests/Result/ResultTypeTest.php
+++ b/tests/Result/ResultTypeTest.php
@@ -22,7 +22,7 @@ class ResultTypeTest extends TypeInferenceTestCase
     public function testFileAsserts(
         string $assertType,
         string $file,
-        mixed ...$args
+        mixed ...$args,
     ): void {
         $this->assertFileAsserts($assertType, $file, ...$args);
     }

--- a/tests/Result/Testing/AssertionsTest.php
+++ b/tests/Result/Testing/AssertionsTest.php
@@ -16,15 +16,15 @@ class ResultAssertionsTestCase extends TestCase
 
 test('assertErr passes with Err result', function () {
     $errResult = Err('error message');
-    
+
     ResultAssertionsTestCase::assertErr($errResult);
-    
+
     expect(true)->toBeTrue(); // If we get here, the assertion passed
 });
 
 test('assertErr fails with Ok result', function () {
     $okResult = Ok('success value');
-    
+
     expect(function () {
         ResultAssertionsTestCase::assertErr($okResult);
     })->toThrow(ExpectationFailedException::class);
@@ -38,15 +38,15 @@ test('assertErr fails with non-Result value', function () {
 
 test('assertOk passes with Ok result', function () {
     $okResult = Ok('success value');
-    
+
     ResultAssertionsTestCase::assertOk($okResult);
-    
+
     expect(true)->toBeTrue(); // If we get here, the assertion passed
 });
 
 test('assertOk fails with Err result', function () {
     $errResult = Err('error message');
-    
+
     expect(function () {
         ResultAssertionsTestCase::assertOk($errResult);
     })->toThrow(ExpectationFailedException::class);
@@ -60,7 +60,7 @@ test('assertOk fails with non-Result value', function () {
 
 test('assertErr with custom message', function () {
     $okResult = Ok('success value');
-    
+
     try {
         ResultAssertionsTestCase::assertErr($okResult, 'Custom error message');
         expect(false)->toBeTrue(); // Should not reach here
@@ -71,7 +71,7 @@ test('assertErr with custom message', function () {
 
 test('assertOk with custom message', function () {
     $errResult = Err('error message');
-    
+
     try {
         ResultAssertionsTestCase::assertOk($errResult, 'Custom error message');
         expect(false)->toBeTrue(); // Should not reach here
@@ -82,12 +82,12 @@ test('assertOk with custom message', function () {
 
 test('isErr constraint returns IsErr instance', function () {
     $constraint = ResultAssertionsTestCase::isErr();
-    
+
     expect($constraint)->toBeInstanceOf(\Superscript\Monads\Result\Testing\IsErr::class);
 });
 
 test('isOk constraint returns IsOk instance', function () {
     $constraint = ResultAssertionsTestCase::isOk();
-    
+
     expect($constraint)->toBeInstanceOf(\Superscript\Monads\Result\Testing\IsOk::class);
 });

--- a/tests/Result/types.php
+++ b/tests/Result/types.php
@@ -53,4 +53,4 @@ assertType('int', $x->unwrapOr(2));
 assertType('int', $x->unwrapOrElse(fn() => 2));
 
 /** @var Result<Option<int>, Throwable> $x */
-assertType(Option::class . '<'.Result::class.'<int, '.Throwable::class.'>>', $x->transpose());
+assertType(Option::class . '<' . Result::class . '<int, ' . Throwable::class . '>>', $x->transpose());

--- a/tests/Writer/WriterTest.php
+++ b/tests/Writer/WriterTest.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+use Superscript\Monads\Writer\Writer;
+
+use function Superscript\Monads\Writer\Writer;
+
+test('value', function () {
+    expect(Writer(42)->value())->toBe(42);
+    expect(Writer('hello')->value())->toBe('hello');
+});
+
+test('log', function () {
+    expect(Writer(42)->log())->toBe([]);
+    expect(Writer(42, ['created'])->log())->toBe(['created']);
+});
+
+test('run', function () {
+    expect(Writer(42, ['created'])->run())->toBe([42, ['created']]);
+});
+
+test('map', function () {
+    $writer = Writer(10, ['initial'])
+        ->map(fn($x) => $x * 2);
+
+    expect($writer->value())->toBe(20);
+    expect($writer->log())->toBe(['initial']);
+});
+
+test('and then', function () {
+    $writer = Writer(10, ['start'])
+        ->andThen(fn($x) => Writer($x * 2, ['doubled']))
+        ->andThen(fn($x) => Writer($x + 1, ['incremented']));
+
+    expect($writer->value())->toBe(21);
+    expect($writer->log())->toBe(['start', 'doubled', 'incremented']);
+});
+
+test('tell', function () {
+    $writer = Writer(42, ['initial'])
+        ->tell(['extra entry']);
+
+    expect($writer->value())->toBe(42);
+    expect($writer->log())->toBe(['initial', 'extra entry']);
+});
+
+test('map log', function () {
+    $writer = Writer(42, ['a', 'b', 'c'])
+        ->mapLog(fn($log) => array_map('strtoupper', $log));
+
+    expect($writer->value())->toBe(42);
+    expect($writer->log())->toBe(['A', 'B', 'C']);
+});
+
+test('inspect', function () {
+    $inspected = null;
+
+    $writer = Writer(42, ['log'])
+        ->inspect(function ($value) use (&$inspected) {
+            $inspected = $value;
+        });
+
+    expect($inspected)->toBe(42);
+    expect($writer->value())->toBe(42);
+    expect($writer->log())->toBe(['log']);
+});
+
+test('reset', function () {
+    $writer = Writer(42, ['a', 'b', 'c'])
+        ->reset([]);
+
+    expect($writer->value())->toBe(42);
+    expect($writer->log())->toBe([]);
+});
+
+test('listen', function () {
+    $writer = Writer(42, ['a', 'b'])
+        ->listen(fn($value, $log) => [$value, count($log)]);
+
+    expect($writer->value())->toBe([42, 2]);
+    expect($writer->log())->toBe(['a', 'b']);
+});
+
+test('chaining preserves immutability', function () {
+    $original = Writer(10, ['start']);
+    $mapped = $original->map(fn($x) => $x * 2);
+
+    expect($original->value())->toBe(10);
+    expect($original->log())->toBe(['start']);
+    expect($mapped->value())->toBe(20);
+    expect($mapped->log())->toBe(['start']);
+});
+
+test('of with custom combiner', function () {
+    $writer = Writer::of('hello', '', fn(string $a, string $b): string => $a . $b)
+        ->tell(' world')
+        ->andThen(fn($v) => Writer::of(strtoupper($v), '!', fn(string $a, string $b): string => $a . $b));
+
+    expect($writer->value())->toBe('HELLO');
+    expect($writer->log())->toBe(' world!');
+});
+
+test('pipeline with logging', function () {
+    $addTax = fn($price) => Writer(
+        $price * 1.2,
+        [sprintf('Added tax: %.2f -> %.2f', $price, $price * 1.2)],
+    );
+
+    $applyDiscount = fn($price) => Writer(
+        $price * 0.9,
+        [sprintf('Applied 10%% discount: %.2f -> %.2f', $price, $price * 0.9)],
+    );
+
+    $writer = Writer(100.0, ['Starting price: 100.00'])
+        ->andThen($addTax)
+        ->andThen($applyDiscount);
+
+    expect($writer->value())->toBe(108.0);
+    expect($writer->log())->toHaveCount(3);
+});

--- a/tests/Writer/types.php
+++ b/tests/Writer/types.php
@@ -1,0 +1,33 @@
+<?php
+
+use Superscript\Monads\Writer\Writer;
+
+use function PHPStan\Testing\assertType;
+use function Superscript\Monads\Writer\Writer;
+
+$writer = Writer(42);
+assertType('Superscript\Monads\Writer\Writer<list<mixed>, int>', $writer);
+assertType('int', $writer->value());
+assertType('list<mixed>', $writer->log());
+assertType('array{int, list<mixed>}', $writer->run());
+
+$mapped = Writer(42)->map(fn(int $x): string => (string) $x);
+assertType('Superscript\Monads\Writer\Writer<list<mixed>, string>', $mapped);
+assertType('string', $mapped->value());
+
+$chained = Writer(42)->andThen(fn(int $x) => Writer($x * 2, ['doubled']));
+assertType('Superscript\Monads\Writer\Writer<list<mixed>, int>', $chained);
+
+$told = Writer(42)->tell(['entry']);
+assertType('Superscript\Monads\Writer\Writer<list<mixed>, int>', $told);
+
+$inspected = Writer(42)->inspect(fn(int $x) => null);
+assertType('Superscript\Monads\Writer\Writer<list<mixed>, int>', $inspected);
+
+$listened = Writer(42)->listen(fn(int $value, $log) => 'result');
+assertType('Superscript\Monads\Writer\Writer<list<mixed>, string>', $listened);
+
+$custom = Writer::of('hello', '', fn(string $a, string $b): string => $a . $b);
+assertType('Superscript\Monads\Writer\Writer<string, string>', $custom);
+assertType('string', $custom->value());
+assertType('string', $custom->log());


### PR DESCRIPTION
## Summary
This PR introduces a new Writer monad to the library, enabling computations that carry values alongside accumulated logs. The Writer monad is useful for tracking side effects, audit trails, and other logging scenarios while maintaining functional purity.

## Key Changes

- **New Writer Monad**: Added `src/Writer/Writer.php` with a complete implementation featuring:
  - `map()` - Transform the value while preserving the log
  - `andThen()` - Chain computations with automatic log combination
  - `tell()` - Append entries to the log
  - `mapLog()` - Transform the accumulated log
  - `inspect()` - Execute side effects without changing the value
  - `reset()` - Clear the log to a new value
  - `listen()` - Access both value and log in a computation
  - `run()` - Extract both value and log as a tuple

- **Helper Function**: Added `src/Writer/functions.php` with a `Writer()` factory function that creates Writers with array-based logs using array spread for combining entries

- **Comprehensive Tests**: Added `tests/Writer/WriterTest.php` with 11 test cases covering all operations and immutability guarantees, plus type assertion tests in `tests/Writer/types.php`

- **Code Quality**: Applied consistent formatting across the codebase:
  - Removed unnecessary blank lines in imports
  - Standardized closure syntax (`fn()` vs `fn ()`)
  - Added trailing commas in multi-line parameter lists
  - Fixed string concatenation formatting in type assertions

- **Autoload Configuration**: Updated `composer.json` to include the new Writer functions file in autoload

## Implementation Details

The Writer monad uses a generic combiner function to support flexible log types (arrays, strings, monoids, etc.). The implementation maintains immutability throughout all operations and properly chains logs when using `andThen()`. The default array-based Writer uses array spread syntax for efficient log combination.

https://claude.ai/code/session_01DZ1sjcUYedPJhLMyCBw7ZW