### PR TITLE
fix: use `Exporter::export(...)` instead of `$this->export()` in `IsOk` and `IsErr`

### DIFF
--- a/src/Result/Testing/IsErr.php
+++ b/src/Result/Testing/IsErr.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Superscript\Monads\Result\Testing;
 
 use PHPUnit\Framework\Constraint\Constraint;
+use PHPUnit\Util\Exporter;
 use Superscript\Monads\Result\Result;
 
 final class IsErr extends Constraint
@@ -21,6 +22,6 @@ final class IsErr extends Constraint
 
     protected function failureDescription(mixed $other): string
     {
-        return sprintf('%s %s', $this->exporter()->export($other), $this->toString());
+        return sprintf('%s %s', Exporter::export($other), $this->toString());
     }
 }

--- a/src/Result/Testing/IsOk.php
+++ b/src/Result/Testing/IsOk.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Superscript\Monads\Result\Testing;
 
 use PHPUnit\Framework\Constraint\Constraint;
+use PHPUnit\Util\Exporter;
 use Superscript\Monads\Result\Result;
 
 final class IsOk extends Constraint
@@ -21,6 +22,6 @@ final class IsOk extends Constraint
 
     protected function failureDescription(mixed $other): string
     {
-        return sprintf('%s %s', $this->exporter()->export($other), $this->toString());
+        return sprintf('%s %s', Exporter::export($other), $this->toString());
     }
 }


### PR DESCRIPTION
In later versions of PHPUnit (v11, v12 and v13) `Constraint:: exporter()` has been removed, meaning calling `$this->assertOk(...)` or `$this->assertErr(...)` will fail with the following message:

```
> Call to undefined method Superscript\Monads\Result\Testing\IsOk::exporter

> Call to undefined method Superscript\Monads\Result\Testing\IsErr::exporter
```

In v11, 12 and 13 the `Constraint` base classes implementation of `failureDescription()` uses `Exporter::export(...)` instead. This PR updates the override in `IsOk` and `IsErr` constraint classes to follow the same pattern.