### PR TITLE
Add PHPStan extension banning panicking monad unwraps

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,5 +29,12 @@
     "allow-plugins": {
       "pestphp/pest-plugin": true
     }
+  },
+  "extra": {
+    "phpstan": {
+      "includes": [
+        "extension.neon"
+      ]
+    }
   }
 }

--- a/extension.neon
+++ b/extension.neon
@@ -1,0 +1,5 @@
+services:
+    -
+        class: Superscript\Monads\PHPStan\NoPanickingMonadUnwrapExtension
+        tags:
+            - phpstan.restrictedMethodUsageExtension

--- a/src/PHPStan/NoPanickingMonadUnwrapExtension.php
+++ b/src/PHPStan/NoPanickingMonadUnwrapExtension.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Superscript\Monads\PHPStan;
+
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\ExtendedMethodReflection;
+use PHPStan\Rules\RestrictedUsage\RestrictedMethodUsageExtension;
+use PHPStan\Rules\RestrictedUsage\RestrictedUsage;
+
+final class NoPanickingMonadUnwrapExtension implements RestrictedMethodUsageExtension
+{
+    private const BANNED = [
+        'Superscript\\Monads\\Result\\Result' => [
+            'unwrap' => "Result::unwrap() throws when the Result is an Err. Handle both cases with match(), document the invariant with expect('why this cannot fail'), or supply a fallback via unwrapOr()/unwrapOrElse().",
+            'unwrapErr' => "Result::unwrapErr() throws when the Result is an Ok. Handle both cases with match(), or document the invariant with expectErr('why this must be an Err').",
+        ],
+        'Superscript\\Monads\\Result\\Err' => [
+            'unwrap' => 'This value is statically known to be an Err, so unwrap() will always throw. Read the error with unwrapErr(), or handle both branches with match().',
+        ],
+        'Superscript\\Monads\\Result\\Ok' => [
+            'unwrapErr' => 'This value is statically known to be an Ok, so unwrapErr() will always throw. Read the value with unwrap(), or handle both branches with match().',
+        ],
+        'Superscript\\Monads\\Option\\Option' => [
+            'unwrap' => "Option::unwrap() throws when the Option is None. Supply a fallback via unwrapOr()/unwrapOrElse(), collapse both cases with mapOrElse(), or document the invariant with expect('why this cannot be None').",
+        ],
+        'Superscript\\Monads\\Option\\None' => [
+            'unwrap' => 'This value is statically known to be None, so unwrap() will always throw. Guard with isSome() first, or supply a fallback via unwrapOr()/unwrapOrElse().',
+        ],
+    ];
+
+    public function isRestrictedMethodUsage(ExtendedMethodReflection $methodReflection, Scope $scope): ?RestrictedUsage
+    {
+        $declaring = $methodReflection->getDeclaringClass()->getName();
+        $name = $methodReflection->getName();
+
+        $message = self::BANNED[$declaring][$name] ?? null;
+        if ($message === null) {
+            return null;
+        }
+
+        return RestrictedUsage::create(errorMessage: $message, identifier: 'monads.panickingUnwrap');
+    }
+}

--- a/tests/PHPStan/NoPanickingMonadUnwrapExtensionTest.php
+++ b/tests/PHPStan/NoPanickingMonadUnwrapExtensionTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Superscript\Monads\Tests\PHPStan;
+
+use PHPStan\Rules\RestrictedUsage\RestrictedMethodUsageRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @extends RuleTestCase<RestrictedMethodUsageRule>
+ */
+final class NoPanickingMonadUnwrapExtensionTest extends RuleTestCase
+{
+    protected function getRule(): Rule
+    {
+        // The rule reads RestrictedMethodUsageExtension services from the container by tag;
+        // getAdditionalConfigFiles() below loads extension.neon so ours is registered.
+        return new RestrictedMethodUsageRule(self::getContainer(), self::createReflectionProvider());
+    }
+
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [__DIR__ . '/../../extension.neon'];
+    }
+
+    public function testFlagsPanickingUnwraps(): void
+    {
+        $this->analyse([__DIR__ . '/data/panicking-unwrap.php'], [
+            [
+                "Result::unwrap() throws when the Result is an Err. Handle both cases with match(), document the invariant with expect('why this cannot fail'), or supply a fallback via unwrapOr()/unwrapOrElse().",
+                15,
+            ],
+            [
+                "Result::unwrapErr() throws when the Result is an Ok. Handle both cases with match(), or document the invariant with expectErr('why this must be an Err').",
+                16,
+            ],
+            [
+                'This value is statically known to be an Ok, so unwrapErr() will always throw. Read the value with unwrap(), or handle both branches with match().',
+                21,
+            ],
+            [
+                'This value is statically known to be an Err, so unwrap() will always throw. Read the error with unwrapErr(), or handle both branches with match().',
+                24,
+            ],
+            [
+                "Option::unwrap() throws when the Option is None. Supply a fallback via unwrapOr()/unwrapOrElse(), collapse both cases with mapOrElse(), or document the invariant with expect('why this cannot be None').",
+                27,
+            ],
+            [
+                'This value is statically known to be None, so unwrap() will always throw. Guard with isSome() first, or supply a fallback via unwrapOr()/unwrapOrElse().',
+                34,
+            ],
+        ]);
+    }
+}

--- a/tests/PHPStan/NoPanickingMonadUnwrapExtensionTest.php
+++ b/tests/PHPStan/NoPanickingMonadUnwrapExtensionTest.php
@@ -38,19 +38,19 @@ final class NoPanickingMonadUnwrapExtensionTest extends RuleTestCase
             ],
             [
                 'This value is statically known to be an Ok, so unwrapErr() will always throw. Read the value with unwrap(), or handle both branches with match().',
-                21,
+                30,
             ],
             [
                 'This value is statically known to be an Err, so unwrap() will always throw. Read the error with unwrapErr(), or handle both branches with match().',
-                24,
+                33,
             ],
             [
                 "Option::unwrap() throws when the Option is None. Supply a fallback via unwrapOr()/unwrapOrElse(), collapse both cases with mapOrElse(), or document the invariant with expect('why this cannot be None').",
-                27,
+                36,
             ],
             [
                 'This value is statically known to be None, so unwrap() will always throw. Guard with isSome() first, or supply a fallback via unwrapOr()/unwrapOrElse().',
-                34,
+                47,
             ],
         ]);
     }

--- a/tests/PHPStan/data/panicking-unwrap.php
+++ b/tests/PHPStan/data/panicking-unwrap.php
@@ -12,23 +12,36 @@ use Superscript\Monads\Result\Ok;
 use Superscript\Monads\Result\Result;
 
 /** @var Result<int, string> $result */
-$result->unwrap();    // flagged: Result::unwrap()
+$result->unwrap(); // flagged: Result::unwrap()
 $result->unwrapErr(); // flagged: Result::unwrapErr()
 $result->match(fn($e) => $e, fn($v) => $v); // NOT flagged
 
+// After a type guard the value is narrowed to the safe variant, so unwrap is allowed.
+if ($result->isOk()) {
+    $result->unwrap(); // NOT flagged: narrowed to Ok
+}
+
+if ($result->isErr()) {
+    $result->unwrapErr(); // NOT flagged: narrowed to Err
+}
+
 /** @var Ok<int> $ok */
-$ok->unwrap();        // NOT flagged: Ok::unwrap() is safe
-fn () => $ok->unwrapErr();     // flagged: narrowed Ok
+$ok->unwrap(); // NOT flagged: Ok::unwrap() is safe
+fn() => $ok->unwrapErr(); // flagged: narrowed Ok
 
 /** @var Err<string> $err */
-fn () => $err->unwrap();       // flagged: narrowed Err
+fn() => $err->unwrap(); // flagged: narrowed Err
 
 /** @var Option<int> $option */
-$option->unwrap();    // flagged: Option::unwrap()
+$option->unwrap(); // flagged: Option::unwrap()
 $option->unwrapOr(0); // NOT flagged
 
+if ($option->isSome()) {
+    $option->unwrap(); // NOT flagged: narrowed to Some
+}
+
 /** @var Some<int> $some */
-$some->unwrap();      // NOT flagged: Some::unwrap() is safe
+$some->unwrap(); // NOT flagged: Some::unwrap() is safe
 
 /** @var None $none */
-fn () => $none->unwrap();      // flagged: narrowed None
+fn() => $none->unwrap(); // flagged: narrowed None

--- a/tests/PHPStan/data/panicking-unwrap.php
+++ b/tests/PHPStan/data/panicking-unwrap.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Superscript\Monads\Tests\PHPStan\data;
+
+use Superscript\Monads\Option\None;
+use Superscript\Monads\Option\Option;
+use Superscript\Monads\Option\Some;
+use Superscript\Monads\Result\Err;
+use Superscript\Monads\Result\Ok;
+use Superscript\Monads\Result\Result;
+
+/** @var Result<int, string> $result */
+$result->unwrap();    // flagged: Result::unwrap()
+$result->unwrapErr(); // flagged: Result::unwrapErr()
+$result->match(fn($e) => $e, fn($v) => $v); // NOT flagged
+
+/** @var Ok<int> $ok */
+$ok->unwrap();        // NOT flagged: Ok::unwrap() is safe
+fn () => $ok->unwrapErr();     // flagged: narrowed Ok
+
+/** @var Err<string> $err */
+fn () => $err->unwrap();       // flagged: narrowed Err
+
+/** @var Option<int> $option */
+$option->unwrap();    // flagged: Option::unwrap()
+$option->unwrapOr(0); // NOT flagged
+
+/** @var Some<int> $some */
+$some->unwrap();      // NOT flagged: Some::unwrap() is safe
+
+/** @var None $none */
+fn () => $none->unwrap();      // flagged: narrowed None


### PR DESCRIPTION
## What

Ships a PHPStan extension (a `RestrictedMethodUsageExtension`) that flags the panicking "escape-hatch" unwrap methods on `Result` and `Option`, nudging callers toward explicit handling.

It reports two situations:

- **May panic** — value typed as the abstract base:
  - `Result::unwrap()` (throws on `Err`), `Result::unwrapErr()` (throws on `Ok`)
  - `Option::unwrap()` (throws on `None`)
- **Always panics** — value narrowed to the failing variant:
  - `Err::unwrap()`, `Ok::unwrapErr()`, `None::unwrap()`

Messages steer toward `match()`, `expect()`/`expectErr()`, `unwrapOr()`/`unwrapOrElse()`, and `mapOrElse()` (the Option message deliberately omits `match()`, which `Option` doesn't have).

## How it's wired

- `extension.neon` registers the service under the `phpstan.restrictedMethodUsageExtension` tag.
- `composer.json` gains `extra.phpstan.includes`, so consumers using `phpstan/extension-installer` pick it up automatically.
- The extension lives in `src/PHPStan/` (namespace `Superscript\Monads\PHPStan`) so it's production-autoloaded for consumers.

The library's **own** analysis is unaffected: it doesn't depend on `extension-installer`, so its internal `unwrap()` usage (e.g. `Option::collect()`) isn't flagged.

## Tests

`tests/PHPStan/NoPanickingMonadUnwrapExtensionTest.php` uses PHPStan's `RuleTestCase` with the built-in `RestrictedMethodUsageRule` against a fixture. The exhaustive assertion verifies all six banned calls are flagged with their exact messages, and that safe calls (`Ok::unwrap`, `Some::unwrap`, `match`, `unwrapOr`) are **not** flagged.

## Verification

- `vendor/bin/pest tests/PHPStan` — passes
- `vendor/bin/phpstan analyse` — library self-analysis stays clean
- `composer validate` — valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)